### PR TITLE
Fix shared test names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__
 *.log
 *.pec
 */dump/*
+*.dyd
+*.tmp

--- a/ProjectView.py
+++ b/ProjectView.py
@@ -84,6 +84,12 @@ class ProjectView(ttk.Frame):
         
     def render(self):
         
+        # reset self.proj in case the project object got changed
+        self.proj = self.parent.project
+        
+        # keep the visible project tile up to date
+        self.proj_header.config(text=self.proj.title)
+        
         frame = self.scroller.frame
         # clear the scroller frame if there's anything in it
         for widget in frame.winfo_children():

--- a/SuperToolGUI.py
+++ b/SuperToolGUI.py
@@ -3,6 +3,7 @@
 
 import tkinter as tk
 from tkinter import ttk
+from tkinter import simpledialog
 from superbackend import *
 from SuperToolFrames import *
 import SuperToolProject as stp
@@ -68,7 +69,7 @@ class SuperToolGUI(tk.Tk):
         file_menu = tk.Menu(self.menubar)
         about_menu = tk.Menu(self.menubar)
 
-        file_menu.add_command(label="New Project", accelerator="ctrl+n") #@TODO make the accelerators do something
+        file_menu.add_command(label="New Project", command=self.new_project, accelerator="ctrl+n") #@TODO make the accelerators do something
         file_menu.add_command(label="Open Project", command=self.open_project, accelerator="ctrl+o")
         file_menu.add_command(label="Save Project", command=self.project.write_to_file_name, accelerator="ctrl+s")
         file_menu.add_command(label="Save Project As", command=self.save_as_project, accelerator="ctrl+shift+s")
@@ -87,6 +88,21 @@ class SuperToolGUI(tk.Tk):
     
     def set_status(self, string):
         self.statusbar_frame.set_text(string)
+    
+    def new_project(self, e=None):
+        # confirmation popup
+        # @TODO make this a string input for a new project name
+        new_project_name = simpledialog.askstring(title="New Project", 
+            prompt="Enter a name for the new project.\nAll unsaved progress will be lost.")
+        if new_project_name:
+            # delete current project class
+            del self.project
+            self.project = stp.Project(new_project_name)
+            # re-render project pane
+            self.proj_frame.render()
+            self.focused_test = None
+            # clear test view
+            self.test_frame.show_focused_test()
     
     def open_project(self, e=None):
         filename = fd.askopenfilename(filetypes=[("Super Tool Project Files", "*.pec")])

--- a/SuperToolProject.py
+++ b/SuperToolProject.py
@@ -8,8 +8,8 @@ from collections import deque
 from pslf_scripts import Voltage_Reference
 
 class Project:
-    def __init__(self, filename=''):
-        self.title = "Untitled Project"
+    def __init__(self, title="Untitled Project", filename=''):
+        self.title = title
         self.file_name = "default-project.pec"
         self.units = {}
     

--- a/SuperToolProject.py
+++ b/SuperToolProject.py
@@ -136,7 +136,7 @@ class Test:
         
         
         
-        [print(i) for i in self.attribute_dict.values()]
+        # [print(i) for i in self.attribute_dict.values()]
         for k,v in kwargs:
             self.attribute_dict[k] = v 
         

--- a/TestView.py
+++ b/TestView.py
@@ -113,7 +113,11 @@ class TestView(ttk.Frame):
         
     def run_simulation(self, *args):
         # print(self.parent.project)
-        self.parent.focused_test.script()
+        if self.parent.focused_test:
+            self.parent.focused_test.script()
+        else:
+            # @TODO make this more elegant
+            print("No focused test to run a script for!")
         # blah = ' '.join([i.get() for i in self.strings])
         # print(blah)
         # self.parent.set_status("Status Bar: " + blah)


### PR DESCRIPTION
fixed bug where right clicking a test that shared a name with a test in a different unit would cause changes to the last created unit in the project pane
added dialog and actions for the new project command in the file menu