### PR TITLE
Save on run

### DIFF
--- a/supertool/SuperToolGUI.py
+++ b/supertool/SuperToolGUI.py
@@ -51,9 +51,6 @@ class SuperToolGUI(tk.Tk):
     # helper method to create and add all of the high level widgets to the 
     # main window. also handles making each row and column resize-able
     def widgets(self):
-        # top bar menu setup
-        self.menu()
-
         ### Frame creation
         # main frame setup, row and column configure for initial size and resizeability
         self.grid_rowconfigure(0, minsize=150, weight=1)
@@ -73,6 +70,8 @@ class SuperToolGUI(tk.Tk):
         self.param_frame.grid(row=0,column=2, columnspan=1, rowspan=1, sticky="nesw")
         self.statusbar_frame.grid(row=1, column=0, columnspan=3, sticky="nesw")
 
+        # top bar menu setup
+        self.menu()
 
     # helper method to set up main window keybinds
     # @TODO check if these are still active in the plot popup
@@ -86,7 +85,8 @@ class SuperToolGUI(tk.Tk):
         self.bind("<Control-S>", self.save_as_project)
         
     # helper method to set up the main file menu at the top of the
-    # window
+    # window. The run menu is also used as a context menu for 
+    # test view.
     def menu(self):
         # create and set menu as the applications titlebar menu
         self.menubar = tk.Menu(self)
@@ -95,6 +95,9 @@ class SuperToolGUI(tk.Tk):
         # sub-menu creation
         file_menu = tk.Menu(self.menubar)
         about_menu = tk.Menu(self.menubar)
+        self.run_menu = tk.Menu(self.menubar)
+        
+        
 
         # add options to the file menu
         # accelerators don't actually do anything, they need to be set
@@ -111,12 +114,25 @@ class SuperToolGUI(tk.Tk):
         file_menu.add_separator()
         file_menu.add_command(label='Exit', command=self.destroy)
 
+        # add options to the run menu
+        self.run_menu.add_command(
+            label="Run",
+            command=self.test_frame.run_simulation,
+            accelerator="F5")
+        self.run_menu.add_command(
+            label="Run Without Saving",
+            command=lambda: self.test_frame.run_simulation(
+                save_on_run=False
+            ),
+            accelerator="ctrl+F5")
+
         # add options to the about menu
         about_menu.add_command(label="About")
         about_menu.add_command(label="Version")
         
         # add the submenus to the menu bar
         self.menubar.add_cascade(label="File", menu=file_menu)
+        self.menubar.add_cascade(label="Run", menu=self.run_menu)
         self.menubar.add_cascade(label="About", menu=about_menu)
     
     # wrapper for statusbar text setting

--- a/supertool/SuperToolGUI.py
+++ b/supertool/SuperToolGUI.py
@@ -78,6 +78,8 @@ class SuperToolGUI(tk.Tk):
     # @TODO check if these are still active in the plot popup
     def keybinds(self):
         self.bind("<F5>", self.test_frame.run_simulation)
+        self.bind("<Control-F5>", lambda e:
+            self.test_frame.run_simulation(save_on_run=False))
         self.bind("<Control-o>", self.open_project)
         self.bind("<Control-s>", self.save_project)
         self.bind("<Control-n>", self.new_project)

--- a/supertool/TestView.py
+++ b/supertool/TestView.py
@@ -194,10 +194,22 @@ class TestView(ttk.Frame):
             # save working directory
             working_dir = os.getcwd()
             
-            # run script
-            for k,v in self.parent.focused_test.attrs.items():
-                print(k, v)
+            try:
+                # print out every variable to terminal
+                for k,v in self.parent.focused_test.attrs.items():
+                    print(k, v)
 
+                # save project @TODO the choice to run without saving
+                self.parent.save_project()
+            # if a parameter is the wrong type or someting like that (float variable
+            # is 0.07f for example) then stop before opening pslf
+            except tk.TclError as e:
+                print()
+                traceback.print_exception(e)
+                print("ERROR: A test parameter is not valid. See above error message.")
+                return
+
+            # run script
             try:
                 self.parent.focused_test.script()
             except SuperToolFatalError as err:

--- a/supertool/TestView.py
+++ b/supertool/TestView.py
@@ -34,6 +34,8 @@ class TestView(ttk.Frame):
 
         self.run_button.bind("<3>", lambda e:
             self.parent.run_menu.post(e.x_root, e.y_root))
+        self.run_button_hover = Hovertip(self.run_button, hover_delay=300,
+            text="Right click to open Run Menu")
         
 
         # Put a scroll frame in the frame

--- a/supertool/TestView.py
+++ b/supertool/TestView.py
@@ -32,6 +32,10 @@ class TestView(ttk.Frame):
         self.run_button = ttk.Button(self, image=self.img, command=self.run_simulation)
         self.run_button.grid(row=0, column=2, sticky='ne')
 
+        self.run_button.bind("<3>", lambda e:
+            self.parent.run_menu.post(e.x_root, e.y_root))
+        
+
         # Put a scroll frame in the frame
         self.scroller = ScrollFrame(self)
         self.frame = self.scroller.frame
@@ -42,7 +46,6 @@ class TestView(ttk.Frame):
         self.columnconfigure(0, weight=1)
         self.columnconfigure(1, weight=1)
         self.columnconfigure(2, weight=1)
-
 
         self.trace_data = []
         # show the focused test. note that when it's used in the initializer,

--- a/supertool/TestView.py
+++ b/supertool/TestView.py
@@ -182,9 +182,11 @@ class TestView(ttk.Frame):
         
     # run the backend PSLF script associated with the focused test's
     # test type
-    def run_simulation(self, *args):
+    def run_simulation(self, event=None, save_on_run=True):
         # print(self.parent.project)
         if self.parent.focused_test:
+            
+            print("save_on_run:", save_on_run)
             
             # @TODO Right here we should do something to check if
             # @TODO Pslf.exe is still running with no window,
@@ -200,7 +202,8 @@ class TestView(ttk.Frame):
                     print(k, v)
 
                 # save project @TODO the choice to run without saving
-                self.parent.save_project()
+                if save_on_run:
+                    self.parent.save_project()
             # if a parameter is the wrong type or someting like that (float variable
             # is 0.07f for example) then stop before opening pslf
             except tk.TclError as e:


### PR DESCRIPTION
Add default ability to save a project to a file when the run button is clicked.
Add run menu to top menu bar and as a context menu for the run button, allowing running without saving.
Add control-F5 to run without saving.